### PR TITLE
Update tests to work when using long to pack longer message types.

### DIFF
--- a/test-fix-44/src/test/java/uk/co/real_logic/artio/integration_tests/AbstractOtfParserTest.java
+++ b/test-fix-44/src/test/java/uk/co/real_logic/artio/integration_tests/AbstractOtfParserTest.java
@@ -17,23 +17,27 @@ package uk.co.real_logic.artio.integration_tests;
 
 import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
-import uk.co.real_logic.artio.dictionary.IntDictionary;
-import uk.co.real_logic.artio.otf.OtfMessageAcceptor;
-import uk.co.real_logic.artio.otf.OtfParser;
-import uk.co.real_logic.artio.util.AsciiBuffer;
-import uk.co.real_logic.artio.util.MutableAsciiBuffer;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+
+
+import uk.co.real_logic.artio.dictionary.LongDictionary;
+import uk.co.real_logic.artio.otf.OtfMessageAcceptor;
+import uk.co.real_logic.artio.otf.OtfParser;
+import uk.co.real_logic.artio.util.AsciiBuffer;
+import uk.co.real_logic.artio.util.MutableAsciiBuffer;
 
 public abstract class AbstractOtfParserTest
 {
     protected final MutableAsciiBuffer buffer = new MutableAsciiBuffer(new byte[16 * 1024]);
     protected final OtfMessageAcceptor acceptor = mock(OtfMessageAcceptor.class);
-    protected final OtfParser parser = new OtfParser(acceptor, new IntDictionary());
+    protected final OtfParser parser = new OtfParser(acceptor, new LongDictionary());
 
     protected void verifyField(final InOrder inOrder, final int tag, final String expectedValue)
     {

--- a/test-fix-44/src/test/java/uk/co/real_logic/artio/integration_tests/SessionMessageValidationTest.java
+++ b/test-fix-44/src/test/java/uk/co/real_logic/artio/integration_tests/SessionMessageValidationTest.java
@@ -49,7 +49,7 @@ public class SessionMessageValidationTest
     private final int refSeqNum;
     private final int refTagId;
     private final char[] refMsgType;
-    private final int msgType;
+    private final long msgType;
     private final SessionRejectReason rejectReason;
 
     private InternalSession session = mock(InternalSession.class);
@@ -71,7 +71,7 @@ public class SessionMessageValidationTest
         final int refSeqNum,
         final int refTagId,
         final char[] refMsgType,
-        final int msgType,
+        final long msgType,
         final SessionRejectReason rejectReason)
     {
         this.message = message;

--- a/test-framework/src/test/java/uk/co/real_logic/artio/acceptance_tests/FakeAcceptanceTestHandler.java
+++ b/test-framework/src/test/java/uk/co/real_logic/artio/acceptance_tests/FakeAcceptanceTestHandler.java
@@ -37,7 +37,7 @@ public class FakeAcceptanceTestHandler extends FakeHandler
         final int libraryId,
         final Session session,
         final int sequenceIndex,
-        final int messageType,
+        final long messageType,
         final long timestampInNs,
         final long position)
     {


### PR DESCRIPTION
Companion PR to [this one](https://github.com/real-logic/artio/pull/306). Updates the integration tests to use long packed message types.